### PR TITLE
 feat: menu icon support local image path

### DIFF
--- a/example/config/config.ts
+++ b/example/config/config.ts
@@ -91,7 +91,7 @@ export default {
             {
               path: '/welcome',
               name: 'one',
-              icon: 'smile',
+              icon: '/favicon.png',
               component: './Welcome',
               routes: [
                 {

--- a/example/src/utils/utils.ts
+++ b/example/src/utils/utils.ts
@@ -2,5 +2,5 @@
 const reg = /(((^https?:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(?::\d+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)$/;
 
 export function isUrl(path: string) {
-  return reg.test(path);
+  return reg.test(path) || path.indexOf('/') === 0;
 }

--- a/src/SiderMenu/BaseMenu.tsx
+++ b/src/SiderMenu/BaseMenu.tsx
@@ -48,6 +48,7 @@ let IconFont = Icon.createFromIconfontCN({
 //   icon: 'setting',
 //   icon: 'icon-geren' #For Iconfont ,
 //   icon: 'http://demo.com/icon.png',
+//   icon: '/favicon.png',
 //   icon: <Icon type="setting" />,
 const getIcon = (icon?: string | React.ReactNode): React.ReactNode => {
   if (typeof icon === 'string') {

--- a/src/SiderMenu/BaseMenu.tsx
+++ b/src/SiderMenu/BaseMenu.tsx
@@ -60,7 +60,7 @@ const getIcon = (icon?: string | React.ReactNode): React.ReactNode => {
               src={icon}
               alt="icon"
               style={{ width: '14px', verticalAlign: 'baseline' }}
-              className="@{ant-prefix}-pro-sider-menu-icon"
+              className="ant-pro-sider-menu-icon"
             />
           )}
         />

--- a/src/SiderMenu/BaseMenu.tsx
+++ b/src/SiderMenu/BaseMenu.tsx
@@ -56,12 +56,7 @@ const getIcon = (icon?: string | React.ReactNode): React.ReactNode => {
       return (
         <Icon
           component={() => (
-            <img
-              src={icon}
-              alt="icon"
-              style={{ width: '14px', verticalAlign: 'baseline' }}
-              className="ant-pro-sider-menu-icon"
-            />
+            <img src={icon} alt="icon" className="ant-pro-sider-menu-icon" />
           )}
         />
       );

--- a/src/SiderMenu/BaseMenu.tsx
+++ b/src/SiderMenu/BaseMenu.tsx
@@ -58,7 +58,8 @@ const getIcon = (icon?: string | React.ReactNode): React.ReactNode => {
             <img
               src={icon}
               alt="icon"
-              className="ant-prefix}-pro-sider-menu-icon"
+              style={{ width: '14px', verticalAlign: 'baseline' }}
+              className="@{ant-prefix}-pro-sider-menu-icon"
             />
           )}
         />

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,5 +2,5 @@
 const reg = /(((^https?:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+(?::\d+)?|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)$/;
 
 export function isUrl(path: string): boolean {
-  return reg.test(path);
+  return reg.test(path) || path.indexOf('/') === 0;
 }


### PR DESCRIPTION
routers icon check if a root-relative url, like '/xxx.png' to support local image path.

ps: 
there is some err about  **className="ant-prefix}-pro-sider-menu-icon"**? 
need check it.

![image](https://user-images.githubusercontent.com/998505/58847843-f2f7b280-86b6-11e9-82f6-34b5daade017.png)
