### PR TITLE
Fixed Header Menu Width issue

### DIFF
--- a/src/TopNavHeader/index.tsx
+++ b/src/TopNavHeader/index.tsx
@@ -31,8 +31,7 @@ export default class TopNavHeader extends Component<
           ? 1200
           : window.innerWidth) -
         280 -
-        120 -
-        40,
+        120
     };
   }
 


### PR DESCRIPTION
After Removing 40 px => 

![image](https://user-images.githubusercontent.com/4658636/59133289-c58d5c00-8977-11e9-89e3-3643fc0b1099.png)


Before that =>
![image](https://user-images.githubusercontent.com/4658636/59133361-0a18f780-8978-11e9-8ea9-6a2840ba701b.png)
