### PR TITLE
修复头部有1px错版问题

### DIFF
--- a/src/GlobalHeader/index.less
+++ b/src/GlobalHeader/index.less
@@ -38,7 +38,7 @@
 
   &-trigger {
     height: @layout-header-height;
-    padding: ~'calc((@{layout-header-height} - 24px) / 2)' 24px;
+    padding: ~'calc((@{layout-header-height} - 26px) / 2)' 24px;
     font-size: 20px;
     cursor: pointer;
     transition: all 0.3s, padding 0s;


### PR DESCRIPTION
头部ant-pro-global-header-trigger有1px错版的情况，仔细看能看到。