### PR TITLE
Fix pageTitleRender prop of ProLayout

### DIFF
--- a/src/getPageTitle.ts
+++ b/src/getPageTitle.ts
@@ -27,7 +27,7 @@ export interface GetPageTitleProps {
   formatMessage: (data: { id: any; defaultMessage?: string }) => string;
 }
 
-const getPageTitle = (props: GetPageTitleProps): string => {
+const getPageTitle = (props: GetPageTitleProps): React.ReactNode => {
   const {
     pathname,
     breadcrumb,


### PR DESCRIPTION
Allow pageTitleRender prop of ProLayout to return a React Element