### PR TITLE
支持 rightContentRender 却未有文档说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ render(<ProLayout />, document.getElementById('root'));
 | collapsed | control menu's collapse and expansion | boolean | true |
 | onCollapse | folding collapse event of menu | (collapsed: boolean) => void | - |
 | headerRender | custom header render method | (props: BasicLayoutProps) => ReactNode | - |
+| rightContentRender | header right content render method | (props: HeaderViewProps) => ReactNode | - |
 | collapsedButtonRender | custom collapsed button method | (collapsed: boolean) => ReactNode | - |
 | footerRender | custom footer render method | (props: BasicLayoutProps) => ReactNode | - |
 | pageTitleRender | custom page title render method | (props: BasicLayoutProps) => ReactNode | - |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -48,6 +48,7 @@ render(<BasicLayout />, document.getElementById('root'));
 | collapsed | 控制菜单的收起和展开 | boolean | true |
 | onCollapse | 菜单的折叠收起事件 | (collapsed: boolean) => void | - |
 | headerRender | 自定义头的 render 方法 | (props: BasicLayoutProps) => ReactNode | - |
+| rightContentRender | 自定义头右部的 render 方法 | (props: HeaderViewProps) => ReactNode | - |
 | collapsedButtonRender | 自定义 collapsed button 的方法 | (collapsed: boolean) => ReactNode | - |
 | footerRender | 自定义页脚的 render 方法 | (props: BasicLayoutProps) => ReactNode | - |
 | pageTitleRender | 自定义页面标题的显示方法 | (props: BasicLayoutProps) => ReactNode | - |


### PR DESCRIPTION
初次使用 `pro-layout`，查看文档无果后觉得此事定有蹊跷。于是查看代码：发现支持 `rightContentRender` 。只是没有文档说明。