### PR TITLE
fix collapsed warning

### DIFF
--- a/src/BasicLayout.tsx
+++ b/src/BasicLayout.tsx
@@ -143,7 +143,7 @@ function useCollapsed(
   onCollapse: BasicLayoutProps['onCollapse'],
 ): [boolean | undefined, BasicLayoutProps['onCollapse']] {
   warning(
-    collapsed === undefined || onCollapse === undefined,
+    (collapsed === undefined) === (onCollapse === undefined),
     'pro-layout: onCollapse and collapsed should exist simultaneously',
   );
 


### PR DESCRIPTION
Fix set onCollapse and collapsed warning

before
```
warning(
    collapsed === undefined ||  onCollapse === undefined,
    'pro-layout: onCollapse and collapsed should exist simultaneously',
  );
```

after
```
warning(
    (collapsed === undefined) === (onCollapse === undefined),
    'pro-layout: onCollapse and collapsed should exist simultaneously',
  );
```