### PR TITLE
Fix Global Header class name

### DIFF
--- a/src/GlobalHeader/index.less
+++ b/src/GlobalHeader/index.less
@@ -1,5 +1,5 @@
 @import '~antd/es/style/themes/default.less';
-@global-header-prefix-cls: ~'@{ant-prefix}-pro-global-header ';
+@global-header-prefix-cls: ~'@{ant-prefix}-pro-global-header';
 
 @pro-header-bg: @component-background;
 @pro-header-hover-bg: @component-background;


### PR DESCRIPTION
This was leading to a wrong css when using less 2.7