### PR TITLE
修复 useState 调用错误

### DIFF
--- a/src/BasicLayout.tsx
+++ b/src/BasicLayout.tsx
@@ -229,15 +229,14 @@ const BasicLayout: React.FC<BasicLayoutProps> = props => {
   /**
    * init variables
    */
-  const isMobile = props.disableMobile
-    ? false
-    : useMedia({
-        id: 'BasicLayout',
-        query: '(max-width: 599px)',
-        targetWindow: window || {
-          matchMedia: () => true,
-        },
-      })[0];
+  const isMobile =
+    useMedia({
+      id: 'BasicLayout',
+      query: '(max-width: 599px)',
+      targetWindow: window || {
+        matchMedia: () => true,
+      },
+    })[0] && !props.disableMobile;
 
   // If it is a fix menu, calculate padding
   // don't need padding in phone mode


### PR DESCRIPTION
原代码[条件调用](https://zh-hans.reactjs.org/docs/hooks-rules.html#only-call-hooks-at-the-top-level)了 `useMedia`，动态修改 `disableMobile` 时会报错。

这里调整了一下，保证在最顶层调用 `useMedia`。