### PR TITLE
BugFix: Modify Header component z-index to 9

### DIFF
--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -125,7 +125,7 @@ class HeaderView extends Component<HeaderViewProps, HeaderViewState> {
     const width = this.getHeadWidth();
     return visible ? (
       <Header
-        style={{ padding: 0, width, zIndex: 2 }}
+        style={{ padding: 0, width, zIndex: 3 }}
         className={fixedHeader ? 'ant-pro-fixed-header' : ''}
       >
         {this.renderContent()}


### PR DESCRIPTION
.ant-tabs-tab-prev, .ant-tabs-tab-next 的 z-index 也为 2 ，在发生滚动的时候会显示在 Header 组件的上方