### PR TITLE
FIX 4.6.2以后的版本PageHeaderWrapper不再生成面包屑

### DIFF
--- a/src/BasicLayout.tsx
+++ b/src/BasicLayout.tsx
@@ -385,8 +385,8 @@ const BasicLayout: React.FC<BasicLayoutProps> = props => {
             <Content className={contentClassName} style={contentStyle}>
               <RouteContext.Provider
                 value={{
-                  breadcrumb: breadcrumbProps,
                   ...defaultProps,
+                  breadcrumb: breadcrumbProps,
                   menuData,
                   isMobile,
                   collapsed,


### PR DESCRIPTION
#170 

### 修复前

![1](https://user-images.githubusercontent.com/13707072/68636747-7c998f00-0537-11ea-89f8-f43ff0a32daa.png)

### 修复后

![2](https://user-images.githubusercontent.com/13707072/68636770-9935c700-0537-11ea-8ca6-9d0ecb355f23.png)