### PR TITLE
bugfix: 服务端菜单渲染异常问题修复

### DIFF
--- a/src/SiderMenu/index.tsx
+++ b/src/SiderMenu/index.tsx
@@ -33,7 +33,7 @@ const SiderMenuWrapper: React.FC<SiderMenuProps> = props => {
     return () =>
       window.cancelAnimationFrame &&
       window.cancelAnimationFrame(animationFrameId);
-  }, menuData);
+  }, [menuData]);
 
   const omitProps = Omit(props, ['className', 'style']);
 


### PR DESCRIPTION
服务端菜单渲染异常问题修复

```
index.js:1 Warning: The final argument passed to useEffect changed size between renders. The order and size of this array must remain constant.

Previous: []
Incoming: [[object Object]]
    in SiderMenuWrapper (created by BasicLayout)
    in section (created by BasicLayout)
    in BasicLayout (created by Context.Consumer)
    in Adapter (created by BasicLayout)
    in div (created by BasicLayout)
    in Provider (created by BasicLayout)
    in BasicLayout (created by BasicLayout)
    in div (created by WaterMark)
    in WaterMark (created by BasicLayout)
```