### PR TITLE
please export  PageHeaderWrapperProps interface

### DIFF
--- a/src/PageHeaderWrapper/index.tsx
+++ b/src/PageHeaderWrapper/index.tsx
@@ -8,7 +8,7 @@ import './index.less';
 import GridContent from '../GridContent';
 import RouteContext, { RouteContextType } from '../RouteContext';
 
-interface PageHeaderTabConfig {
+export interface PageHeaderTabConfig {
   tabList?: TabPaneProps[];
   tabActiveKey?: TabsProps['activeKey'];
   onTabChange?: TabsProps['onChange'];
@@ -16,7 +16,7 @@ interface PageHeaderTabConfig {
   tabProps?: TabsProps;
 }
 
-interface PageHeaderWrapperProps
+export interface PageHeaderWrapperProps
   extends PageHeaderTabConfig,
     Omit<PageHeaderProps, 'title'> {
   title?: React.ReactNode | false;


### PR DESCRIPTION
我不喜欢下图这个标题，觉得它占了不少屏幕，我想基于PageHeaderWrapper封装一个简单的组件，默认title={false}, 所以可以像你们封装的其他组件一样导出这个接口（PageHeaderWrapperProps）吗？这样我可以少写好些代码😁
![image](https://user-images.githubusercontent.com/20815934/72063967-d5a65900-3315-11ea-916b-a26a7e508bec.png)
