### PR TITLE
bugfix: 解决配置了路由base配置时，面包屑跳转prefix丢失的问题

### DIFF
--- a/example/config/config.ts
+++ b/example/config/config.ts
@@ -42,6 +42,7 @@ const plugins: IPlugin[] = [
 
 export default {
   plugins,
+  // base: 'prefix',
   block: {
     defaultGitUrl: 'https://github.com/ant-design/pro-blocks',
   },

--- a/src/utils/getBreadcrumbProps.tsx
+++ b/src/utils/getBreadcrumbProps.tsx
@@ -92,8 +92,11 @@ const conversionFromProps = (
   return breadcrumbList
     .map((item) => {
       const { title, href } = item;
+      // For application that has configured router base
+      // @ts-ignore
+      const realPath = window.routerBase === '/' ? href : `${window.routerBase}${href}`;
       return {
-        path: href,
+        path: realPath,
         breadcrumbName: title,
       };
     })
@@ -113,6 +116,9 @@ const conversionFromLocation = (
   // Loop data mosaic routing
   const extraBreadcrumbItems: AntdBreadcrumbProps['routes'] = pathSnippets
     .map((url) => {
+      // For application that has configured router base
+      // @ts-ignore
+      const realPath = window.routerBase === '/' ? url : `${window.routerBase}${url}`;
       const currentBreadcrumb = getBreadcrumb(breadcrumbMap, url);
       if (currentBreadcrumb.inherited) {
         return { path: '', breadcrumbName: '' };
@@ -121,7 +127,7 @@ const conversionFromLocation = (
       const { hideInBreadcrumb } = currentBreadcrumb;
       return name && !hideInBreadcrumb
         ? {
-            path: url,
+            path: realPath,
             breadcrumbName: name,
             component: currentBreadcrumb.component,
           }

--- a/src/utils/getBreadcrumbProps.tsx
+++ b/src/utils/getBreadcrumbProps.tsx
@@ -95,7 +95,7 @@ const conversionFromProps = (
       const { title, href } = item;
       // For application that has configured router base
       // @ts-ignore
-      const { routerBase } = isBrowser() ? window : {};
+      const { routerBase = '/' } = isBrowser() ? window : {};
       const realPath = routerBase === '/' ? href : `${routerBase}${href}`;
       return {
         path: realPath,
@@ -120,7 +120,7 @@ const conversionFromLocation = (
     .map((url) => {
       // For application that has configured router base
       // @ts-ignore
-      const { routerBase } = isBrowser() ? window : {};
+      const { routerBase = '/' } = isBrowser() ? window : {};
       const realPath = routerBase === '/' ? url : `${routerBase}${url}`;
       const currentBreadcrumb = getBreadcrumb(breadcrumbMap, url);
       if (currentBreadcrumb.inherited) {

--- a/src/utils/getBreadcrumbProps.tsx
+++ b/src/utils/getBreadcrumbProps.tsx
@@ -5,6 +5,7 @@ import pathToRegexp from 'path-to-regexp';
 import { Settings } from '../defaultSettings';
 import { MenuDataItem, MessageDescriptor } from '../typings';
 import { urlToList } from './pathTools';
+import { isBrowser } from './utils';
 
 export interface BreadcrumbProps {
   breadcrumbList?: { title: string; href: string }[];
@@ -94,7 +95,8 @@ const conversionFromProps = (
       const { title, href } = item;
       // For application that has configured router base
       // @ts-ignore
-      const realPath = window.routerBase === '/' ? href : `${window.routerBase}${href}`;
+      const { routerBase } = isBrowser() ? window : {};
+      const realPath = routerBase === '/' ? href : `${routerBase}${href}`;
       return {
         path: realPath,
         breadcrumbName: title,
@@ -118,7 +120,8 @@ const conversionFromLocation = (
     .map((url) => {
       // For application that has configured router base
       // @ts-ignore
-      const realPath = window.routerBase === '/' ? url : `${window.routerBase}${url}`;
+      const { routerBase } = isBrowser() ? window : {};
+      const realPath = routerBase === '/' ? url : `${routerBase}${url}`;
       const currentBreadcrumb = getBreadcrumb(breadcrumbMap, url);
       if (currentBreadcrumb.inherited) {
         return { path: '', breadcrumbName: '' };


### PR DESCRIPTION
解决配置了路由base配置时，面包屑跳转prefix丢失的问题

关联issue: https://github.com/ant-design/ant-design-pro/issues/5104