### PR TITLE
🐛bugfix: 修复title 非string时导致的错误场景

### DIFF
--- a/src/BasicLayout.tsx
+++ b/src/BasicLayout.tsx
@@ -421,7 +421,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = (props) => {
     }
   }, [stringify(props.location)]);
 
-  useDocumentTitle(pageTitleInfo.title, props.title);
+  useDocumentTitle(pageTitleInfo, props.title);
 
   return (
     <MenuCounter.Provider>

--- a/src/BasicLayout.tsx
+++ b/src/BasicLayout.tsx
@@ -421,7 +421,7 @@ const BasicLayout: React.FC<BasicLayoutProps> = (props) => {
     }
   }, [stringify(props.location)]);
 
-  useDocumentTitle(pageTitleInfo.title);
+  useDocumentTitle(pageTitleInfo.title, props.title);
 
   return (
     <MenuCounter.Provider>

--- a/src/WrapContent.tsx
+++ b/src/WrapContent.tsx
@@ -75,7 +75,7 @@ class ResizeObserverContent extends React.Component<
         contentHeight: height,
       });
     }
-  }, 100);
+  }, 10);
 
   componentWillUnmount() {
     window.clearTimeout(this.resize.id);

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -8,7 +8,7 @@ export function useDocumentTitle(
 ) {
   const titleText = typeof title === 'string' ? title : appDefaultTitle;
   useEffect(() => {
-    if (isBrowser()) {
+    if (isBrowser() && titleText) {
       document.title = titleText;
     }
   }, [title]);

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,10 +1,12 @@
 import { useEffect } from 'react';
 import { isBrowser } from './utils';
+import defaultSettings from '../defaultSettings';
 
 export function useDocumentTitle(title: string) {
+  const titleText = typeof title === 'string' ? title : defaultSettings.title;
   useEffect(() => {
     if (isBrowser()) {
-      document.title = title;
+      document.title = titleText;
     }
   }, [title]);
 }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -2,8 +2,11 @@ import { useEffect } from 'react';
 import { isBrowser } from './utils';
 import defaultSettings from '../defaultSettings';
 
-export function useDocumentTitle(title: string) {
-  const titleText = typeof title === 'string' ? title : defaultSettings.title;
+export function useDocumentTitle(title: string, appDefaultTitle?: string) {
+  const titleText =
+    typeof title === 'string'
+      ? title
+      : appDefaultTitle || defaultSettings.title;
   useEffect(() => {
     if (isBrowser()) {
       document.title = titleText;

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -2,11 +2,11 @@ import { useEffect } from 'react';
 import { isBrowser } from './utils';
 import defaultSettings from '../defaultSettings';
 
-export function useDocumentTitle(title: string, appDefaultTitle?: string) {
-  const titleText =
-    typeof title === 'string'
-      ? title
-      : appDefaultTitle || defaultSettings.title;
+export function useDocumentTitle(
+  title: string,
+  appDefaultTitle: string = defaultSettings.title,
+) {
+  const titleText = typeof title === 'string' ? title : appDefaultTitle;
   useEffect(() => {
     if (isBrowser()) {
       document.title = titleText;

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -3,13 +3,18 @@ import { isBrowser } from './utils';
 import defaultSettings from '../defaultSettings';
 
 export function useDocumentTitle(
-  title: string,
+  titleInfo: {
+    title: string;
+    id: string;
+    pageName: string;
+  },
   appDefaultTitle: string = defaultSettings.title,
 ) {
-  const titleText = typeof title === 'string' ? title : appDefaultTitle;
+  const titleText =
+    typeof titleInfo.pageName === 'string' ? titleInfo.title : appDefaultTitle;
   useEffect(() => {
     if (isBrowser() && titleText) {
       document.title = titleText;
     }
-  }, [title]);
+  }, [titleInfo.title]);
 }


### PR DESCRIPTION
* 修复title 非string 时导致的错误显示
关联issue:  https://github.com/ant-design/ant-design-pro-layout/issues/396