### PR TITLE
Fixed Theme Color setting drawer

### DIFF
--- a/src/SettingDrawer/ThemeColor.tsx
+++ b/src/SettingDrawer/ThemeColor.tsx
@@ -27,7 +27,6 @@ export interface ThemeColorProps {
     key: string;
     color: string;
   }[];
-  title?: string;
   value: string;
   onChange: (color: string) => void;
   formatMessage: (data: { id: any; defaultMessage?: string }) => string;
@@ -36,14 +35,13 @@ export interface ThemeColorProps {
 const ThemeColor: React.ForwardRefRenderFunction<
   HTMLDivElement,
   ThemeColorProps
-> = ({ colors, title, value, onChange, formatMessage }, ref) => {
+> = ({ colors, value, onChange, formatMessage }, ref) => {
   const colorList = colors || [];
   if (colorList.length < 1) {
     return null;
   }
   return (
     <div className="theme-color" ref={ref}>
-      <h3 className="theme-color-title">{title}</h3>
       <div className="theme-color-content">
         {colorList.map(({ key, color }) => {
           const themeKey = genThemeToString(key);

--- a/src/SettingDrawer/index.tsx
+++ b/src/SettingDrawer/index.tsx
@@ -575,20 +575,26 @@ const SettingDrawer: React.FC<SettingDrawerProps> = (props) => {
             onChange={(value) => changeSetting('navTheme', value, hideLoading)}
           />
         </Body>
-
-        <ThemeColor
-          title={formatMessage({ id: 'app.setting.themecolor' })}
-          value={primaryColor}
-          colors={
-            hideColors
-              ? []
-              : themeList.colorList[navTheme === 'realDark' ? 'dark' : 'light']
-          }
-          formatMessage={formatMessage}
-          onChange={(color) =>
-            changeSetting('primaryColor', color, hideLoading)
-          }
-        />
+        <Body
+          title={formatMessage({
+            id: 'app.setting.themecolor',
+            defaultMessage: 'Theme color',
+          })}
+          prefixCls={baseClassName}
+        >
+          <ThemeColor
+            value={primaryColor}
+            colors={
+              hideColors
+                ? []
+                : themeList.colorList[navTheme === 'realDark' ? 'dark' : 'light']
+            }
+            formatMessage={formatMessage}
+            onChange={(color) =>
+              changeSetting('primaryColor', color, hideLoading)
+            }
+          />
+        </Body>
 
         <Divider />
 


### PR DESCRIPTION
This fixes the Theme Colors not following the theme guidelines, especially in dark mode:

Before:
<img width="300" alt="Screen Shot 2020-07-14 at 8 34 41 AM" src="https://user-images.githubusercontent.com/463175/87426871-e75f0680-c5ad-11ea-87a4-2e66bfc7602d.png">
<img width="614" alt="Screen Shot 2020-07-14 at 8 35 07 AM" src="https://user-images.githubusercontent.com/463175/87426888-eb8b2400-c5ad-11ea-9e78-bb9f6f1539a7.png">

After:
<img width="540" alt="Screen Shot 2020-07-14 at 8 40 25 AM" src="https://user-images.githubusercontent.com/463175/87426901-f1810500-c5ad-11ea-99e6-87f244736a6a.png">
